### PR TITLE
specify main class for exec-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,14 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<mainClass>de.imise.excel_api.GenerateJavaFiles</mainClass>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Now you can run it as "mvn exec:java" without needing to package it as a jar.