### PR TITLE
Add metaclass support

### DIFF
--- a/src/main/java/de/imise/excel_api/owl_export/Config.java
+++ b/src/main/java/de/imise/excel_api/owl_export/Config.java
@@ -22,6 +22,7 @@ public class Config {
   private Map<String, String> propertyPrefixes = new HashMap<>();
   private List<String> annotationProperties = new ArrayList<>();
   private List<String> objectProperties = new ArrayList<>();
+  private List<String> metaClasses = new ArrayList<>();
   private Map<String, List<String>> metadata = new HashMap<>();
 
   public static Config get(String yamlFilePath) {
@@ -123,8 +124,16 @@ public class Config {
     return objectProperties;
   }
 
+  public List<String> getMetaClasses() {
+    return metaClasses;
+  }
+
   public void setObjectProperties(List<String> objectProperties) {
     this.objectProperties = objectProperties;
+  }
+
+  public void setMetaClasses(List<String> metaClasses) {
+    this.metaClasses = metaClasses;
   }
 
   public Map<String, List<String>> getMetadata() {


### PR DESCRIPTION
A critical problem of using pySHACL for ontology validation is that SHACL shapes are based on instances, not classes.
A workaround is to use metaclasses, see <https://stackoverflow.com/questions/70756167/how-to-apply-shacl-to-subclasses-instead-of-instances> and <https://github.com/RDFLib/pySHACL/issues/60>.

Thus this PR adds metaclass support with the "metaClasses" optional config.yml list property like so:

```yaml
[...]
metaClasses:           
  - https://annosaxfdm.de/ontology/Bone
  - https://annosaxfdm.de/ontology/BonePart  
  - https://annosaxfdm.de/ontology/BoneCompound
  - https://annosaxfdm.de/ontology/Tooth
  - https://annosaxfdm.de/ontology/Phenotype
  - https://annosaxfdm.de/ontology/AnatomicalPoint 
  - https://annosaxfdm.de/ontology/AnatomicalLine 
  - https://annosaxfdm.de/ontology/AnatomicalAxis
  - https://annosaxfdm.de/ontology/AnatomicalPlane
  - https://annosaxfdm.de/ontology/RelativeAnatomicalLocation
[...]
```

For every element of metaClasses it will create a meta class by appending "Class" to the URI.
For example, for <https://annosaxfdm.de/ontology/Bone> it will generate <https://annosaxfdm.de/ontology/BoneClass>.
Then for every class x which is (transitive or not) a subclass of anno:Bone it will add the triple `x rdf:type anno:BoneClass.

## Disclaimer

If you don't need this you don't need to merge it into master.
I think it is very useful but if no one else has this use case I will just keep it in my own branch.