### PR TITLE
Add individual support (#60)

### DIFF
--- a/src/main/java/de/imise/excel_api/owl_export/Config.java
+++ b/src/main/java/de/imise/excel_api/owl_export/Config.java
@@ -6,8 +6,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.semanticweb.owlapi.formats.RDFJsonLDDocumentFormat;
 import org.semanticweb.owlapi.formats.RDFXMLDocumentFormat;
 import org.semanticweb.owlapi.model.IRI;
@@ -23,6 +25,7 @@ public class Config {
   private List<String> annotationProperties = new ArrayList<>();
   private List<String> objectProperties = new ArrayList<>();
   private List<String> metaClasses = new ArrayList<>();
+  private Set<String> individualClasses = new HashSet<>();
   private Map<String, List<String>> metadata = new HashMap<>();
 
   public static Config get(String yamlFilePath) {
@@ -128,12 +131,20 @@ public class Config {
     return metaClasses;
   }
 
+  public Set<String> getIndividualClasses() {
+    return individualClasses;
+  }
+
   public void setObjectProperties(List<String> objectProperties) {
     this.objectProperties = objectProperties;
   }
 
   public void setMetaClasses(List<String> metaClasses) {
     this.metaClasses = metaClasses;
+  }
+
+  public void setIndividualClasses(Set<String> individualClasses) {
+    this.individualClasses = individualClasses;
   }
 
   public Map<String, List<String>> getMetadata() {

--- a/src/main/java/de/imise/excel_api/owl_export/SimpleOWLExport.java
+++ b/src/main/java/de/imise/excel_api/owl_export/SimpleOWLExport.java
@@ -142,7 +142,12 @@ public class SimpleOWLExport {
   }
 
   private void addClass(OWLClass cls, OWLClass superCls) {
-    ont.add(fac.getOWLSubClassOfAxiom(cls, superCls));
+    if (config.getIndividualClasses().contains(superCls.getIRI().getIRIString())) {
+      var ind = fac.getOWLNamedIndividual(cls.getIRI());
+      ont.add(fac.getOWLClassAssertionAxiom(superCls, ind));
+    } else {
+      ont.add(fac.getOWLSubClassOfAxiom(cls, superCls));
+    }
   }
 
   private void addMetaClasses(OWLClass meta, OWLClass c) {


### PR DESCRIPTION
Allow configuring "individualClasses" as requested in #60.
This will cause all entities under those classes to be added as individuals instead of subclasses.

For example in the `anno.yml` SMOG simple OWL export config file:

```yml
individualClasses:
  - https://annosaxfdm.de/ontology/VisualDefinition
  - https://annosaxfdm.de/ontology/Source
```

Source spreadsheet excerpt:

![Screenshot from 2024-04-09 13-27-33](https://github.com/Onto-Med/SMOG/assets/839577/de1b6d68-f302-4bbd-b6a7-e90e27ab36c8)

## Result

  <!-- https://annosaxfdm.de/ontology/IMAGE0001 -->
  
```xml
  <owl:NamedIndividual rdf:about="https://annosaxfdm.de/ontology/IMAGE0001">
      <rdf:type rdf:resource="https://annosaxfdm.de/ontology/VisualDefinition"/>
      <ontology:file>Os_femoris_OL_anterior.png</ontology:file>
      <ontology:headline>Os femoris links anterior</ontology:headline>
      <ontology:id>IMAGE_0001</ontology:id>
      <ontology:location rdf:resource="https://biosciences.hs-mittweida.de/anno/Os_femoris_OL_anterior.png"/>
      <ontology:source rdf:resource="https://annosaxfdm.de/ontology/SO0110"/>  
      <ontology:source rdf:resource="https://annosaxfdm.de/ontology/SO0111"/>
      <ontology:source rdf:resource="https://annosaxfdm.de/ontology/SO0112"/>
  </owl:NamedIndividual>
```